### PR TITLE
Fixed issue with empty displays on faderport 16

### DIFF
--- a/src/controls/csurf_display.cpp
+++ b/src/controls/csurf_display.cpp
@@ -17,11 +17,11 @@ void CSurf_Display::SendValue(int line)
 
     midiSysExData.evt.frame_offset = 0;
     midiSysExData.evt.size = 0;
-    midiSysExData.evt.midi_message[midiSysExData.evt.size++] = SYSEX_HEADER[0];
-    midiSysExData.evt.midi_message[midiSysExData.evt.size++] = SYSEX_HEADER[1];
-    midiSysExData.evt.midi_message[midiSysExData.evt.size++] = SYSEX_HEADER[2];
-    midiSysExData.evt.midi_message[midiSysExData.evt.size++] = SYSEX_HEADER[3];
-    midiSysExData.evt.midi_message[midiSysExData.evt.size++] = SYSEX_HEADER[4];
+    midiSysExData.evt.midi_message[midiSysExData.evt.size++] = SYSEX_START;
+    midiSysExData.evt.midi_message[midiSysExData.evt.size++] = SYSEX_MANUFACTURER_1;
+    midiSysExData.evt.midi_message[midiSysExData.evt.size++] = SYSEX_MANUFACTURER_2;
+    midiSysExData.evt.midi_message[midiSysExData.evt.size++] = SYSEX_MANUFACTURER_3;
+    midiSysExData.evt.midi_message[midiSysExData.evt.size++] = device_id;
     midiSysExData.evt.midi_message[midiSysExData.evt.size++] = DISPLAY_ACTION_DISPLAY;
     midiSysExData.evt.midi_message[midiSysExData.evt.size++] = channel;
     midiSysExData.evt.midi_message[midiSysExData.evt.size++] = line;
@@ -40,7 +40,7 @@ void CSurf_Display::SendValue(int line)
         count++;
     }
 
-    midiSysExData.evt.midi_message[midiSysExData.evt.size++] = 0xF7;
+    midiSysExData.evt.midi_message[midiSysExData.evt.size++] = SYSEX_END;
 
     if (m_midiout)
     {
@@ -58,16 +58,16 @@ void CSurf_Display::SendMode()
 
     midiSysExData.evt.frame_offset = 0;
     midiSysExData.evt.size = 0;
-    midiSysExData.evt.midi_message[midiSysExData.evt.size++] = SYSEX_HEADER[0];
-    midiSysExData.evt.midi_message[midiSysExData.evt.size++] = SYSEX_HEADER[1];
-    midiSysExData.evt.midi_message[midiSysExData.evt.size++] = SYSEX_HEADER[2];
-    midiSysExData.evt.midi_message[midiSysExData.evt.size++] = SYSEX_HEADER[3];
-    midiSysExData.evt.midi_message[midiSysExData.evt.size++] = SYSEX_HEADER[4];
+    midiSysExData.evt.midi_message[midiSysExData.evt.size++] = SYSEX_START;
+    midiSysExData.evt.midi_message[midiSysExData.evt.size++] = SYSEX_MANUFACTURER_1;
+    midiSysExData.evt.midi_message[midiSysExData.evt.size++] = SYSEX_MANUFACTURER_2;
+    midiSysExData.evt.midi_message[midiSysExData.evt.size++] = SYSEX_MANUFACTURER_3;
+    midiSysExData.evt.midi_message[midiSysExData.evt.size++] = device_id;
     midiSysExData.evt.midi_message[midiSysExData.evt.size++] = DISPLAY_ACTION_MODE;
     midiSysExData.evt.midi_message[midiSysExData.evt.size++] = channel;
     midiSysExData.evt.midi_message[midiSysExData.evt.size++] = 0x00 + displayMode;
 
-    midiSysExData.evt.midi_message[midiSysExData.evt.size++] = 0xF7;
+    midiSysExData.evt.midi_message[midiSysExData.evt.size++] = SYSEX_END;
 
     if (m_midiout)
     {
@@ -80,14 +80,15 @@ void CSurf_Display::SetValue(int line, Alignment _alignment, const char *_value,
     // We have to convert the char array to a string. Somehow the simple conversion makes it crash
     char buffer[250];
     snprintf(buffer, sizeof(buffer), "%s", _value);
-    std::string strVal = buffer;
+    std::string strVal = std::string(buffer);
 
-    if (line > 6) {
+    if (line > 6)
+    {
         return;
     }
 
     // If values have not changed, we do nothing
-    if (strVal == values[line] && alignment[line] == _alignment && inverted[line] == invert && !force)
+    if (strVal.compare(values[line]) == 0 && alignment[line] == _alignment && inverted[line] == invert && !force)
     {
         return;
     }

--- a/src/controls/csurf_display.hpp
+++ b/src/controls/csurf_display.hpp
@@ -13,15 +13,15 @@ protected:
     Inverted inverted[7] = {NON_INVERT, NON_INVERT, NON_INVERT, NON_INVERT, NON_INVERT, NON_INVERT, NON_INVERT};
     Alignment alignment[7] = {ALIGN_LEFT, ALIGN_LEFT, ALIGN_LEFT, ALIGN_LEFT, ALIGN_LEFT, ALIGN_LEFT, ALIGN_LEFT};
     DisplayMode displayMode;
-
     midi_Output *m_midiout;
+    int device_id;
 
     void SendValue(int line);
 
     void SendMode();
 
 public:
-    CSurf_Display(int channel, midi_Output *m_midiout) : channel(channel), m_midiout(m_midiout) {};
+    CSurf_Display(int channel, midi_Output *m_midiout, int device_id) : channel(channel), m_midiout(m_midiout), device_id(device_id) {};
 
     ~CSurf_Display() {};
 

--- a/src/controls/csurf_display_resources.hpp
+++ b/src/controls/csurf_display_resources.hpp
@@ -4,6 +4,14 @@
 static const int HEADER_LENGTH = 5;
 static int SYSEX_HEADER[HEADER_LENGTH] = {0xf0, 0x00, 0x01, 0x06, 0x02};
 
+static int SYSEX_START = 0xf0;
+static int SYSEX_MANUFACTURER_1 = 0x00;
+static int SYSEX_MANUFACTURER_2 = 0x01;
+static int SYSEX_MANUFACTURER_3 = 0x06;
+static int SYSEX_DEVICE_FP8 = 0x02;
+static int SYSEX_DEVICE_FP16 = 0x16;
+static int SYSEX_END = 0xf7;
+
 enum DisplayActions
 {
     DISPLAY_ACTION_DISPLAY = 0x12,

--- a/src/csurf_faderport_8/csurf_fp_8_track.cpp
+++ b/src/csurf_faderport_8/csurf_fp_8_track.cpp
@@ -6,12 +6,13 @@
 
 CSurf_FP_8_Track::CSurf_FP_8_Track(int index, CSurf_Context *context, midi_Output *m_midiout) : context(context)
 {
+    int device_id = context->GetNbChannels() == 8 ? SYSEX_DEVICE_FP8 : SYSEX_DEVICE_FP16;
     selectButton = new CSurf_ColorButton(ButtonColorWhite, SelectButtons[index], BTN_VALUE_OFF, m_midiout);
     soloButton = new CSurf_Button(SoloButtons[index], BTN_VALUE_OFF, m_midiout);
     muteButton = new CSurf_Button(MuteButtons[index], BTN_VALUE_OFF, m_midiout);
     fader = new CSurf_Fader(index, 0, m_midiout);
     valueBar = new CSurf_Valuebar(index, 0, m_midiout);
-    display = new CSurf_Display(index, m_midiout);
+    display = new CSurf_Display(index, m_midiout, device_id);
     vuMeter = new CSurf_VuMeter(index, m_midiout);
 }
 CSurf_FP_8_Track::~CSurf_FP_8_Track()
@@ -25,10 +26,10 @@ CSurf_FP_8_Track::~CSurf_FP_8_Track()
 void CSurf_FP_8_Track::ClearTrack()
 {
     this->SetTrackColor(ButtonColorWhite);
-    this->SetDisplayLine(0, ALIGN_LEFT, "", NON_INVERT, true);
-    this->SetDisplayLine(1, ALIGN_LEFT, "", NON_INVERT, true);
-    this->SetDisplayLine(2, ALIGN_CENTER, "", NON_INVERT, true);
-    this->SetDisplayLine(3, ALIGN_CENTER, "", NON_INVERT, true);
+    this->SetDisplayLine(0, ALIGN_LEFT, "", NON_INVERT, false);
+    this->SetDisplayLine(1, ALIGN_LEFT, "", NON_INVERT, false);
+    this->SetDisplayLine(2, ALIGN_CENTER, "", NON_INVERT, false);
+    this->SetDisplayLine(3, ALIGN_CENTER, "", NON_INVERT, false);
     this->SetMuteButtonValue(BTN_VALUE_OFF);
     this->SetSoloButtonValue(BTN_VALUE_OFF);
     this->SetSelectButtonValue(BTN_VALUE_OFF);

--- a/src/csurf_faderport_8/csurf_fp_8_track_manager.cpp
+++ b/src/csurf_faderport_8/csurf_fp_8_track_manager.cpp
@@ -86,7 +86,7 @@ public:
         WDL_PtrList<MediaTrack> media_tracks = navigator->GetBankTracks();
         std::vector<std::string> time_code;
 
-        if (has_hast_touched_fx_enabled != context->GetLastTouchedFxMode() && !context->GetLastTouchedFxMode())
+        if (has_hast_touched_fx_enabled != context->GetLastTouchedFxMode())
         {
             forceUpdate = true;
         }


### PR DESCRIPTION
Fixed issue with empty displays on faderport 16 and 
stopped spamming the device when no track available for channel