### PR TITLE
Fix plugin mapping crash, fix uninvert on fader

### DIFF
--- a/src/csurf_faderport_8/csurf_fp_8_plugin_control_manager.cpp
+++ b/src/csurf_faderport_8/csurf_fp_8_plugin_control_manager.cpp
@@ -106,7 +106,9 @@ public:
             {
                 if (!displayStepSize)
                 {
-                    track->SetDisplayLine(2, ALIGN_CENTER, ini[paramKey]["name"].c_str(), INVERT, forceUpdate);
+                    Inverted inverted = ini[paramKey].has("uninvert-label") && ini[paramKey]["uninvert-label"] == "1" ? NON_INVERT : INVERT;
+					
+                    track->SetDisplayLine(2, ALIGN_CENTER, ini[paramKey]["name"].c_str(), inverted, forceUpdate);
                     TrackFX_GetFormattedParamValue(media_track, pluginId, stoi(ini[paramKey]["param"]), buffer, sizeof(buffer));
                     track->SetDisplayLine(3, ALIGN_CENTER, buffer, NON_INVERT, forceUpdate);
                 }

--- a/src/csurf_faderport_8/csurf_fp_8_ui_plugin_mapping_page.cpp
+++ b/src/csurf_faderport_8/csurf_fp_8_ui_plugin_mapping_page.cpp
@@ -1069,6 +1069,11 @@ public:
 
     void Reset() override
     {
+        if (selected_plugin < 0)
+        {
+            return;
+        }
+		
         channel_offset = 0;
         selected_channel = 0;
         SetPluginData();


### PR DESCRIPTION
1) Plugin mapping page crashes when pressing cancel before selecting a plugin

2) Uninvert is ignored for faders. It is only available for select buttons