### PR TITLE
Fix plugin developer parsing

### DIFF
--- a/src/shared/csurf_daw.cpp
+++ b/src/shared/csurf_daw.cpp
@@ -328,7 +328,17 @@ std::string DAW::GetTrackFxDeveloper(MediaTrack *media_track, const int fxIndex)
     }
 
     const std::vector<std::string> plugin_name_parts = split(plugin_name, " (");
-    std::string developer = plugin_name_parts.at(plugin_name_parts.size() - 1);
+	std::string developer;
+	int max = pluginNameParts.size() - 1;
+	
+    for (int i = max; i > 0; i--)
+    {
+        if (pluginNameParts.at(i).find(" out)") == std::string::npos)
+        {
+            developer = pluginNameParts.at(i);
+            break;
+        }
+    }
 
     if (!developer.empty()) {
         developer.pop_back();


### PR DESCRIPTION
Developer incorrectly parsed when plugin has outputs. Additional (XX out) is appended to plugin string and because developer is found by splitting " (" then the last index will be the output instead of the developer name. This prevents mapped plugin from being used with edit plugins mode on FP.