### PR TITLE
Fix plugin request string

### DIFF
--- a/src/shared/csurf_utils.cpp
+++ b/src/shared/csurf_utils.cpp
@@ -529,6 +529,12 @@ std::string toLowerCase(std::string value) {
     return value;
 }
 
+std::string toUpperCase(std::string value)
+{
+    std::transform(value.begin(), value.end(), value.begin(), ::toupper);
+    return value;
+}
+
 double boolToDouble(const bool value) {
     return value ? 1.0 : 0.0;
 }
@@ -537,3 +543,63 @@ bool doubleToBool(const double value) {
     return value > 0.0;
 }
 
+std::vector<std::string> GetPluginTypes()
+{
+    std::vector<std::string> plugin_types = {
+        "vst",
+        "vsti",
+        "vst3",
+        "vst3i",
+        "au",
+        "aui",
+        "clap",
+        "clapi",
+        "lv2",
+        "lv2i" };
+    return plugin_types;
+}
+
+std::string FormatPluginType(std::string value)
+{
+    std::string plugin_type = toUpperCase(value);
+
+    if (value.back() == 'i')
+    {
+        plugin_type.pop_back();
+        plugin_type.push_back('i');
+    }
+
+    return plugin_type;
+}
+
+std::string GetPluginRequestString(std::string plugin_origname, std::string plugin_type)
+{
+    std::vector<std::string> allowed_plugin_types = GetPluginTypes();
+    auto it_type = std::find(allowed_plugin_types.begin(), allowed_plugin_types.end(), plugin_type);
+    if (it_type == allowed_plugin_types.end())
+    {
+        // ------------------------------------------------------------------------
+        // Not found, the plugin type has either not been set or is invalid!
+        // ------------------------------------------------------------------------
+        MessageBox(NULL, "Unable to determine plugin type!\n\nRun this action and see if the plugin is listed:\n\n\"Reasonus: Set the correct plugin type for the already created plugins\"\n\nIf it is listed, set the plugin type and try again.\n\n", "ERROR: ReaSonus Native", 0);
+        return "";
+    }
+    else
+    {
+        // ------------------------------------------------------------------------
+        // VST actually means version 1 of the VST spec. Most plugins nowadays are
+        // using version 2.x of the VST spec. VST2 is what needs to be used during
+        // plugin insertion, otherwise no plugin will be found unless there is an
+        // alternate version also installed.
+        // ------------------------------------------------------------------------
+        if (plugin_type == "vst" || plugin_type == "vsti")
+        {
+            plugin_type.replace(0, 3, "VST2");
+        }
+    }
+
+    // Make sure the properly formatted type is included when adding a plugin!
+    std::string plugin_name_with_type = FormatPluginType(plugin_type) + ": " + plugin_origname;
+
+    return plugin_name_with_type;
+}

--- a/src/shared/csurf_utils.hpp
+++ b/src/shared/csurf_utils.hpp
@@ -396,6 +396,13 @@ std::string createPathName(const std::vector<std::string> &path_elements);
 std::string toLowerCase(std::string value);
 
 /**
+ * Convert a string to all uppercase
+ * @param value Value to convert
+ * @return
+ */
+std::string toUpperCase(std::string value);
+
+/**
  * Convert a boolean value to a double
  * @param value Value to convert
  * @return
@@ -408,5 +415,28 @@ double boolToDouble(bool value);
  * @return
  */
 bool doubleToBool(double value);
+
+/**
+ * Fetch a list of plugin types allowed in the plugin mapping
+ * @return
+ */
+std::vector<std::string> GetPluginTypes();
+
+/**
+ * Convert the plugin type to uppercase and if it's an instrument, make sure the i is lowercase
+ * @param value Plugin type to format
+ * @return
+ */
+std::string FormatPluginType(std::string value);
+
+/**
+ * Check the plugin is one of the allowed types and prefix the "name (developer)" string with the type
+ * 
+ * Also change VST to VST2, assuming it would be v2.x and not the older v1.x which is obsolete
+ * @param plugin_origname Original name of the plugin from TrackFX_GetFXName
+ * @param plugin_type Identifier to determine which plugin package to load
+ * @return
+ */
+std::string GetPluginRequestString(std::string plugin_origname, std::string plugin_type);
 
 #endif // CSURF_UTILS_H_

--- a/src/ui/pages/csurf_ui_fp_8_plugin_mapping_page.cpp
+++ b/src/ui/pages/csurf_ui_fp_8_plugin_mapping_page.cpp
@@ -175,7 +175,9 @@ protected:
         // Create a track, add the plugin and start reading the params
         InsertTrackAtIndex(0, false);
         MediaTrack *media_track = GetTrack(nullptr, 0);
-        const int exist = TrackFX_AddByName(media_track, plugin_params["global"]["origname"].c_str(), false, -1);
+
+        std::string plugin_request_string = GetPluginRequestString(plugin_params["global"]["origname"], plugin_params["global"]["type"]);
+        const int exist = TrackFX_AddByName(media_track, plugin_request_string.c_str(), false, -1);
         DeleteTrack(media_track);
 
         return exist > -1;
@@ -192,7 +194,9 @@ protected:
         InsertTrackAtIndex(0, false);
         MediaTrack *media_track = GetTrack(nullptr, 0);
 
-        TrackFX_AddByName(media_track, plugin_params["global"]["origname"].c_str(), false, -1);
+        // Placeholder until first iteration of plugin caching is implemented
+        std::string plugin_request_string = GetPluginRequestString(plugin_params["global"]["origname"], plugin_params["global"]["type"]);
+        TrackFX_AddByName(media_track, plugin_request_string.c_str(), false, -1);
 
         for (int i = 0; i < TrackFX_GetNumParams(media_track, 0); i++) {
             const std::string param_name = DAW::GetTrackFxParamName(media_track, 0, i);

--- a/src/ui/windows/csurf_ui_plugin_type_mapping.hpp
+++ b/src/ui/windows/csurf_ui_plugin_type_mapping.hpp
@@ -37,17 +37,7 @@ private:
     std::vector<std::vector<std::string>> plugins;
     int selected_plugin = -1;
 
-    std::vector<std::string> plugin_types = {
-        "vst",
-        "vsti",
-        "vst3",
-        "vst3i",
-        "au",
-        "aui",
-        "clap",
-        "clapi",
-        "lv2",
-        "lv2i"};
+    std::vector<std::string> plugin_types = GetPluginTypes();
     int selected_plugin_type = -1;
 
     bool add_type_clicked = false;


### PR DESCRIPTION
There are problems with the plugin request string used by `TrackFX_AddByName()` in functions `PluginExists()` and `GetPluginParams()`.

### Example

The VST2, VST3, and CLAP versions of a plugin `Comp` by developer `Dev` are installed. We currently use the plugin request string below to try and load the plugin on a track...

* `Comp (Dev)` automatic selection, prefer VST3

But there are request strings to target specific types...

1) `VST3: Comp (Dev)` request VST3
2) `VST: Comp (Dev)` request VST, but it's not installed so VST3 loads instead
3) `VST2: Comp (Dev)` request VST2 (we normally see this as VST in track FX)
4) `CLAP: Comp (Dev)` request CLAP

So in this example the correct plugin might not be loaded, depending on users plugin installation. This affects parameters because as we discussed previously, VST3 can have lots of extra parameters that are not present with other plugin types. Currently, you can try to request CLAP from plugin mapper UI but VST3 parameters may be shown if the VST3 version exists alongside the CLAP version.

<img width="1072" height="278" alt="PluginRequestStringFix" src="https://github.com/user-attachments/assets/b5a16db7-a601-4620-9bce-3440d3f59ac6" />

.
With VST, the request string can be shown as VST in track FX, but it's not correct when trying to add a plugin that isn't very old. If the plugin uses v2.x of VST specification then the VST2 prefix needs to be used.

Another problem is once plugin mappings have been made for a plugin type, if the plugin type is then uninstalled but other types are not uninstalled and the user tries to access the plugin mapping for that uninstalled type again, REAPER will make an automatic selection for the wrong plugin type and the mapped parameters can potentially be in the wrong locations, which is confusing. Requesting specific types fixes this by showing the plugin is not installed anymore screen.