### PR TITLE
Publish changes from Faderport banking for readability in LUA scripts

### DIFF
--- a/src/csurf_faderport_8/csurf_fp_8_main.cpp
+++ b/src/csurf_faderport_8/csurf_fp_8_main.cpp
@@ -44,6 +44,7 @@ class CSurf_FaderPort : public IReaperControlSurface {
   CSurf_FP_8_Track *lastTouchedFxTrack;
 
   DWORD surface_update_lastrun;
+  int last_published_offset = -12345;
   DWORD surface_update_keepalive;
   DWORD surface_update_settings_check;
 
@@ -433,6 +434,15 @@ public:
           DAW::SetExtState(EXT_STATE_KEY_SAVED_SETTINGS, EXT_STATE_VALUE_FALSE, false);
         }
       }
+    }
+
+    // Publish the surface's current bank offset whenever it changed during
+    // this cycle, regardless of which code path changed it. Lets external
+    // tools (e.g. ReaScripts) follow the surface's banking exactly.
+    const int current_offset = trackNavigator->GetOffset();
+    if (current_offset != last_published_offset) {
+      DAW::SetExtState("FP_TRACK_OFFSET", std::to_string(current_offset), false);
+      last_published_offset = current_offset;
     }
   }
 

--- a/src/csurf_faderport_8/csurf_fp_8_main.cpp
+++ b/src/csurf_faderport_8/csurf_fp_8_main.cpp
@@ -44,7 +44,6 @@ class CSurf_FaderPort : public IReaperControlSurface {
   CSurf_FP_8_Track *lastTouchedFxTrack;
 
   DWORD surface_update_lastrun;
-  int last_published_offset = -12345;
   DWORD surface_update_keepalive;
   DWORD surface_update_settings_check;
 
@@ -434,15 +433,6 @@ public:
           DAW::SetExtState(EXT_STATE_KEY_SAVED_SETTINGS, EXT_STATE_VALUE_FALSE, false);
         }
       }
-    }
-
-    // Publish the surface's current bank offset whenever it changed during
-    // this cycle, regardless of which code path changed it. Lets external
-    // tools (e.g. ReaScripts) follow the surface's banking exactly.
-    const int current_offset = trackNavigator->GetOffset();
-    if (current_offset != last_published_offset) {
-      DAW::SetExtState("FP_TRACK_OFFSET", std::to_string(current_offset), false);
-      last_published_offset = current_offset;
     }
   }
 

--- a/src/csurf_faderport_8/csurf_fp_8_navigator.cpp
+++ b/src/csurf_faderport_8/csurf_fp_8_navigator.cpp
@@ -276,7 +276,7 @@ CSurf_FP_8_Navigator::CSurf_FP_8_Navigator(CSurf_Context *context) : context(con
     HandleAllTracksFilter();
     has_mute = false;
     has_solo = false;
-    DAW::SetExtState("FP_TRACK_OFFSET", std::to_string(track_offset), false);
+    PublishOffset();
 }
 
 MediaTrack *CSurf_FP_8_Navigator::GetTrackByIndex(const int index) {
@@ -340,7 +340,7 @@ void CSurf_FP_8_Navigator::SetOffset(const int offset) {
     } else {
         track_offset = offset;
     }
-    DAW::SetExtState("FP_TRACK_OFFSET", std::to_string(track_offset), false);
+    PublishOffset();
 }
 
 int CSurf_FP_8_Navigator::GetOffset() const {
@@ -372,7 +372,7 @@ void CSurf_FP_8_Navigator::IncrementOffset(const int count) {
     } else {
         track_offset = tracks.GetSize() - context->GetNbBankChannels();
     }
-    DAW::SetExtState("FP_TRACK_OFFSET", std::to_string(track_offset), false);
+    PublishOffset();
     UpdateMixerPosition();
 }
 
@@ -382,7 +382,7 @@ void CSurf_FP_8_Navigator::DecrementOffset(const int count) {
     } else {
         track_offset = 0;
     }
-    DAW::SetExtState("FP_TRACK_OFFSET", std::to_string(track_offset), false);
+    PublishOffset();
     UpdateMixerPosition();
 }
 
@@ -392,7 +392,7 @@ void CSurf_FP_8_Navigator::HandlePanEncoderChange(const int value) {
     }
     if (!hasBit(value, 6) && track_offset < tracks.GetSize() - context->GetNbChannels()) {
         track_offset += 1;
-        DAW::SetExtState("FP_TRACK_OFFSET", std::to_string(track_offset), false);
+        PublishOffset();
     }
 }
 
@@ -485,4 +485,14 @@ bool CSurf_FP_8_Navigator::HasFilter(const int filter_index) {
                selected_filters.end(),
                find(selected_filters.begin(), selected_filters.end(), filter_index)
            ) != 0;
+}
+
+void CSurf_FP_8_Navigator::PublishOffset() {
+    // Publish the surface's current bank offset whenever it changed during
+    // this cycle, regardless of which code path changed it. Lets external
+    // tools (e.g. ReaScripts) follow the surface's banking exactly.
+    if (track_offset != last_published_offset) {
+      DAW::SetExtState(FP_TRACK_OFFSET, current_offset, false);
+      last_published_offset = current_offset;
+    }
 }

--- a/src/csurf_faderport_8/csurf_fp_8_navigator.cpp
+++ b/src/csurf_faderport_8/csurf_fp_8_navigator.cpp
@@ -276,6 +276,7 @@ CSurf_FP_8_Navigator::CSurf_FP_8_Navigator(CSurf_Context *context) : context(con
     HandleAllTracksFilter();
     has_mute = false;
     has_solo = false;
+    DAW::SetExtState("FP_TRACK_OFFSET", std::to_string(track_offset), false);
 }
 
 MediaTrack *CSurf_FP_8_Navigator::GetTrackByIndex(const int index) {
@@ -339,6 +340,7 @@ void CSurf_FP_8_Navigator::SetOffset(const int offset) {
     } else {
         track_offset = offset;
     }
+    DAW::SetExtState("FP_TRACK_OFFSET", std::to_string(track_offset), false);
 }
 
 int CSurf_FP_8_Navigator::GetOffset() const {
@@ -370,6 +372,7 @@ void CSurf_FP_8_Navigator::IncrementOffset(const int count) {
     } else {
         track_offset = tracks.GetSize() - context->GetNbBankChannels();
     }
+    DAW::SetExtState("FP_TRACK_OFFSET", std::to_string(track_offset), false);
     UpdateMixerPosition();
 }
 
@@ -379,6 +382,7 @@ void CSurf_FP_8_Navigator::DecrementOffset(const int count) {
     } else {
         track_offset = 0;
     }
+    DAW::SetExtState("FP_TRACK_OFFSET", std::to_string(track_offset), false);
     UpdateMixerPosition();
 }
 
@@ -388,6 +392,7 @@ void CSurf_FP_8_Navigator::HandlePanEncoderChange(const int value) {
     }
     if (!hasBit(value, 6) && track_offset < tracks.GetSize() - context->GetNbChannels()) {
         track_offset += 1;
+        DAW::SetExtState("FP_TRACK_OFFSET", std::to_string(track_offset), false);
     }
 }
 

--- a/src/csurf_faderport_8/csurf_fp_8_navigator.cpp
+++ b/src/csurf_faderport_8/csurf_fp_8_navigator.cpp
@@ -1,6 +1,7 @@
 #include "csurf_fp_8_navigator.hpp"
 #include "../shared/csurf_daw.hpp"
 #include "csurf_fp_8_navigator_filters.hpp"
+#include "../shared/csurf.h"
 
 void CSurf_FP_8_Navigator::UpdateMixerPosition() {
     const WDL_PtrList<MediaTrack> bank = GetBankTracks();
@@ -492,7 +493,7 @@ void CSurf_FP_8_Navigator::PublishOffset() {
     // this cycle, regardless of which code path changed it. Lets external
     // tools (e.g. ReaScripts) follow the surface's banking exactly.
     if (track_offset != last_published_offset) {
-      DAW::SetExtState(FP_TRACK_OFFSET, current_offset, false);
-      last_published_offset = current_offset;
+      DAW::SetExtState(FP_TRACK_OFFSET, track_offset, false);
+      last_published_offset = track_offset;
     }
 }

--- a/src/csurf_faderport_8/csurf_fp_8_navigator.hpp
+++ b/src/csurf_faderport_8/csurf_fp_8_navigator.hpp
@@ -65,6 +65,7 @@ class CSurf_FP_8_Navigator {
     WDL_PtrList<MediaTrack> tracks;
     bool has_solo;
     bool has_mute;
+    int last_published_offset = -12345;
     bool track_touched[16] = {
         false,
         false,
@@ -119,6 +120,8 @@ class CSurf_FP_8_Navigator {
     void HandleTrackCustomMultiSelectFilter();
 
     bool TrackIsInBankTracks(MediaTrack *media_track);
+
+    void PublishOffset();
 
 public:
     explicit CSurf_FP_8_Navigator(CSurf_Context *context);

--- a/src/csurf_faderport_8/csurf_fp_8_navigator.hpp
+++ b/src/csurf_faderport_8/csurf_fp_8_navigator.hpp
@@ -65,7 +65,7 @@ class CSurf_FP_8_Navigator {
     WDL_PtrList<MediaTrack> tracks;
     bool has_solo;
     bool has_mute;
-    int last_published_offset = -12345;
+    int last_published_offset = -1;
     bool track_touched[16] = {
         false,
         false,

--- a/src/shared/csurf.h
+++ b/src/shared/csurf.h
@@ -27,5 +27,6 @@ inline const char *EXT_STATE_SECTION = "ReaSonus";
 inline const char *EXT_STATE_KEY_SAVED_SETTINGS = "saved_settings";
 inline const char *EXT_STATE_KEY_UI_LANGUAGE = "language";
 inline const char *EXT_STATE_KEY_VERSION = "version";
+inline const char *FP_TRACK_OFFSET = "FP_TRACK_OFFSET";
 
 #endif

--- a/src/shared/csurf_daw.cpp
+++ b/src/shared/csurf_daw.cpp
@@ -831,6 +831,6 @@ void DAW::SetExtState(const std::string &key, const std::string &value, const bo
     ::SetExtState(EXT_STATE_SECTION, key.c_str(), value.c_str(), persist);
 }
 
-void DAW::SetExtState(const std::string &key, const int value, const bool persist) {
+void DAW::SetExtState(const std::string &key, const double value, const bool persist) {
     ::SetExtState(EXT_STATE_SECTION, key.c_str(), std::to_string(value).c_str(), persist);
 }

--- a/src/shared/csurf_daw.cpp
+++ b/src/shared/csurf_daw.cpp
@@ -831,6 +831,6 @@ void DAW::SetExtState(const std::string &key, const std::string &value, const bo
     ::SetExtState(EXT_STATE_SECTION, key.c_str(), value.c_str(), persist);
 }
 
-void DAW::SetExtState(const std::string &key, const double value, const bool persist) {
+void DAW::SetExtState(const std::string &key, const int value, const bool persist) {
     ::SetExtState(EXT_STATE_SECTION, key.c_str(), std::to_string(value).c_str(), persist);
 }

--- a/src/shared/csurf_daw.cpp
+++ b/src/shared/csurf_daw.cpp
@@ -830,3 +830,7 @@ std::string DAW::GetExtState(const std::string &key, std::string default_value) 
 void DAW::SetExtState(const std::string &key, const std::string &value, const bool persist) {
     ::SetExtState(EXT_STATE_SECTION, key.c_str(), value.c_str(), persist);
 }
+
+void DAW::SetExtState(const std::string &key, const int value, const bool persist) {
+    ::SetExtState(EXT_STATE_SECTION, key.c_str(), std::to_string(value).c_str(), persist);
+}

--- a/src/shared/csurf_daw.hpp
+++ b/src/shared/csurf_daw.hpp
@@ -808,12 +808,12 @@ public:
     static void SetExtState(const std::string &key, const std::string &value, bool persist);
 
     /**
-     * Set the value to the Ext state with the given key for integer values
+     * Set the value to the Ext state with the given key for double values
      * @param key The key to store the value under
-     * @param value The integer value to store
+     * @param value The double value to store
      * @param persist Set to true will store it persistent between projects. Otherwise, it will be stored for the current session
      */
-    static void SetExtState(const std::string &key, int value, bool persist);
+    static void SetExtState(const std::string &key, double value, bool persist);
 };
 
 #endif

--- a/src/shared/csurf_daw.hpp
+++ b/src/shared/csurf_daw.hpp
@@ -808,12 +808,12 @@ public:
     static void SetExtState(const std::string &key, const std::string &value, bool persist);
 
     /**
-     * Set the value to the Ext state with the given key for double values
+     * Set the value to the Ext state with the given key for int values
      * @param key The key to store the value under
-     * @param value The double value to store
+     * @param value The int value to store
      * @param persist Set to true will store it persistent between projects. Otherwise, it will be stored for the current session
      */
-    static void SetExtState(const std::string &key, double value, bool persist);
+    static void SetExtState(const std::string &key, int value, bool persist);
 };
 
 #endif

--- a/src/shared/csurf_daw.hpp
+++ b/src/shared/csurf_daw.hpp
@@ -802,10 +802,18 @@ public:
     /**
      * Set the value to the Ext state with the given key
      * @param key The key to store the value under
-     * @param value The value to store
+     * @param value The string value to store
      * @param persist Set to true will store it persistent between projects. Otherwise, it will be stored for the current session
      */
     static void SetExtState(const std::string &key, const std::string &value, bool persist);
+
+    /**
+     * Set the value to the Ext state with the given key for integer values
+     * @param key The key to store the value under
+     * @param value The integer value to store
+     * @param persist Set to true will store it persistent between projects. Otherwise, it will be stored for the current session
+     */
+    static void SetExtState(const std::string &key, int value, bool persist);
 };
 
 #endif


### PR DESCRIPTION
Hello, 

I have created a small contribution here that publishes track offset in the Faderport 8/16 when banking (both bank & channel increment/decrement) so that an external script can read this and update based on bank changes. 

The script I am using leverages this contribution by displaying the current 16 tracks on the Faderport so that I don't have to look at the small screens anymore :) 

https://pastebin.com/yQHD1xyC

<img width="1785" height="904" alt="image" src="https://github.com/user-attachments/assets/4228a35e-e9f2-4d38-b64b-42f00f8714ce" />

Now when I bank scroll on the Faderport, this script can read these values and update accordingly. 

Validated on Windows, do not have a Mac to validate that build. The build completes fine on my fork: https://github.com/mcvittal/Reasonus-Native/actions/runs/29468790465 but the release fails and I'm not sure why. I was able to download the build assets just fine. 

NOTE: This contribution & lua script was created with Claude.  