### PR TITLE
Add script command feature

### DIFF
--- a/src/actions/action_fp_8_setting_script_command.cpp
+++ b/src/actions/action_fp_8_setting_script_command.cpp
@@ -1,0 +1,67 @@
+#include "action_fp_8_setting_script_command.hpp"
+#include <mini/ini.h>
+
+#include "../shared/csurf_reasonus_settings.hpp"
+#include "../shared/csurf_utils.hpp"
+
+#define STRINGIZE_DEF(x) #x
+#define STRINGIZE(x) STRINGIZE_DEF(x)
+#define min(a, b) ((a) < (b) ? (a) : (b))
+#define max(a, b) ((a) > (b) ? (a) : (b))
+
+// confine my plugin to namespace
+namespace ACTION_FP_8_SETTING_SCRIPT_COMMAND {
+    // some global non-const variables
+    // the necessary 'evil'
+    int command_id{0};
+    constexpr auto command_name = "REASONUS_FP8_SCRIPT_COMMAND";
+    constexpr auto action_name = "Reasonus: Custom command triggered by script";
+    custom_action_register_t action = {0, command_name, action_name, nullptr};
+
+    std::string ReadIniValue(std::string group, std::string item) {
+        return ReaSonusSettings::GetInstance(FP_8)->GetSetting(group, item);
+    }
+
+    void WriteIniValue(std::string group, std::string item, std::string value) {
+        ReaSonusSettings::GetInstance(FP_8)->SetAndSaveSetting(group, item, value);
+    }
+
+    // this gets called when my plugin action is run (e.g. from action list)
+	bool runCommand(int command, int flag) {
+        // check command
+        if (command != command_id) {
+            return false;
+        }
+		
+		WriteIniValue("surface", "script-command-id", std::to_string(flag));
+		
+		return true;
+	}
+	
+    void GetVersion(int *majorOut, int *minorOut, int *patchOut, int *tweakOut, char *commitOut, int commitOut_sz) {
+        *majorOut = PROJECT_VERSION_MAJOR;
+        *minorOut = PROJECT_VERSION_MINOR;
+        *patchOut = PROJECT_VERSION_PATCH;
+        *tweakOut = PROJECT_VERSION_TWEAK;
+        const char *commit = STRINGIZE(PROJECT_VERSION_COMMIT);
+        std::copy(commit, commit + min(commitOut_sz - 1, (int)strlen(commit)), commitOut);
+        commitOut[min(commitOut_sz - 1, (int)strlen(commit))] = '\0'; // Ensure null termination
+    }
+
+    // when my plugin gets loaded
+    // function to register my plugins 'stuff' with REAPER
+    void Register() {
+        // register action name and get command_id
+        command_id = plugin_register("custom_action", &action);
+
+        // register run action/command
+		plugin_register("hookcommand", (void *) runCommand);
+    }
+
+    // shutdown, time to exit
+    // modern C++11 syntax
+    auto Unregister() -> void {
+        plugin_register("-custom_action", &action);
+		plugin_register("-hookcommand", (void *) runCommand);
+    }
+} // namespace ACTION_FP_8_SETTING_SCRIPT_COMMAND

--- a/src/actions/action_fp_8_setting_script_command.hpp
+++ b/src/actions/action_fp_8_setting_script_command.hpp
@@ -1,0 +1,13 @@
+#include "config.h"
+
+#include <WDL/wdltypes.h> // might be unnecessary in future
+#include <gsl/gsl>
+#include <reaper_plugin_functions.h>
+
+namespace ACTION_FP_8_SETTING_SCRIPT_COMMAND
+{
+    extern REAPER_PLUGIN_HINSTANCE hInstance; // used for dialogs, if any
+    auto Register() -> void;
+    auto Unregister() -> void;
+
+} // namespace ACTION_FP_8_SETTING_SCRIPT_COMMAND

--- a/src/csurf_faderport_8/csurf_fp_8_main.cpp
+++ b/src/csurf_faderport_8/csurf_fp_8_main.cpp
@@ -50,6 +50,7 @@ class CSurf_FaderPort : public IReaperControlSurface {
   DWORD surface_update_lastrun;
   DWORD surface_update_keepalive;
   DWORD surface_update_settings_check;
+  DWORD surface_update_script_command;
 
   I18n *i18n = I18n::GetInstance();
   ReaSonusSettings *settings = ReaSonusSettings::GetInstance(FP_8);
@@ -442,6 +443,20 @@ public:
         m_midiout->Send(0xa0, 0x00, 0x00, -1);
       }
       CheckProjectChange();
+	  
+      /**
+       * Incoming command from script
+       *
+       */
+      if ((now - surface_update_script_command) >= 500) {
+          surface_update_script_command = now;
+          int script_command_id = stoi(settings->GetSetting("surface", "script-command-id", "-1"));
+
+          if (ScriptCommand(script_command_id)) {
+              settings->SetAndSaveSetting("surface", "script-command-id", "-1");
+              settings->UpdateSettings();
+          }
+      }
 
       /**
        * every 1500 ms we check if the settings have been saved.
@@ -458,6 +473,64 @@ public:
         }
       }
     }
+  }
+
+  bool ScriptCommand(int script_command_id) {
+
+      if (script_command_id > 999 && script_command_id < 1016) {
+          script_command_id -= 1000;
+          faderManager->HandlePluginsButtonClick(0x7f, true);
+          faderManager->HandleSoloClick(script_command_id, 0x7f);
+          return true;
+
+      } else {
+          switch (script_command_id) {
+          case 501:
+              faderManager->HandleTrackButtonClick(0x7f);
+              return true;
+
+          case 502:
+              faderManager->HandlePluginsButtonClick(0x7f, false);
+              return true;
+
+          case 503:
+              faderManager->HandlePluginsButtonClick(0x7f, true);
+              return true;
+
+          case 504:
+              faderManager->HandleSendButtonClick(0x7f, false);
+              return true;
+
+          case 505:
+              faderManager->HandleSendButtonClick(0x7f, true);
+              return true;
+
+          case 506:
+              context->SetShiftLeftLocked(true);
+              faderManager->HandleSendButtonClick(0x7f, false);
+              context->SetShiftLeftLocked(false);
+              return true;
+
+          case 507:
+              context->SetShiftLeftLocked(true);
+              faderManager->HandleSendButtonClick(0x7f, true);
+              context->SetShiftLeftLocked(false);
+              return true;
+
+          case 508:
+              faderManager->HandlePanButtonClick(0x7f, false);
+              return true;
+
+          case 509:
+              faderManager->HandlePanButtonClick(0x7f, true);
+              return true;
+
+          default:
+              return false;
+          }
+      }
+
+      return false;
   }
 
   void OnTrackSelection(MediaTrack *media_track) override {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,7 @@
 #include "actions/action_fp_8_setting_fader_reset.hpp"
 #include "actions/action_fp_8_setting_master_fader_mode.hpp"
 #include "actions/action_fp_8_setting_momentary_mute_solo.hpp"
+#include "actions/action_fp_8_setting_script_command.hpp"
 #include "actions/action_fp_8_setting_swap_shift_buttons.hpp"
 #include "actions/action_fp_8_setting_untouch_last_touched_param.hpp"
 #include "actions/action_fp_v2_setting_control_hidden_tracks.hpp"
@@ -60,6 +61,7 @@ REAPER_PLUGIN_DLL_EXPORT auto REAPER_PLUGIN_ENTRYPOINT(
     ACTION_FP_8_SETTING_FADER_RESET_SETTING::Unregister();
     ACTION_FP_8_SETTING_MASTER_FADER_MODE::Unregister();
     ACTION_FP_8_SETTING_MOMENTARY_MUTE_SOLO::Unregister();
+	ACTION_FP_8_SETTING_SCRIPT_COMMAND::Unregister();
     ACTION_FP_8_SETTING_SWAP_SHIFT_BUTTONS::Unregister();
     ACTION_FP_8_SETTING_UNTOUCH_LAST_TOUCHED_PARAM::Unregister();
     ACTION_FP_V2_SETTING_CONTROL_HIDDEN_TRACKS::Unregister();
@@ -108,6 +110,7 @@ REAPER_PLUGIN_DLL_EXPORT auto REAPER_PLUGIN_ENTRYPOINT(
   ACTION_FP_8_SETTING_FADER_RESET_SETTING::Register();
   ACTION_FP_8_SETTING_MASTER_FADER_MODE::Register();
   ACTION_FP_8_SETTING_MOMENTARY_MUTE_SOLO::Register();
+  ACTION_FP_8_SETTING_SCRIPT_COMMAND::Register();
   ACTION_FP_8_SETTING_SWAP_SHIFT_BUTTONS::Register();
   ACTION_FP_8_SETTING_UNTOUCH_LAST_TOUCHED_PARAM::Register();
   ACTION_FP_V2_SETTING_CONTROL_HIDDEN_TRACKS::Register();


### PR DESCRIPTION
This feature allows ReaSonus to accept commands from scripts.

I created a new action that collects a command / FX ID from the flag and stores it in an internal setting. In the main loop, there is a check to see if the internal setting has been changed to anything other than default and if so it checks to see which command should be executed. I've so far only supported changing fader modes and also the editing of a plugin on a specific FX ID of the selected track.

The script below can target the 1st, 2nd etc. instance of a plugin or the last instance. It can also move the found instance to the end of the list to make sure it's always treated like a simulated post fader FX. It can hide all floating windows before switching to the plugin and also detect whether there is an instance of it already open. With no FX windows open, running the script will switch to the mapping for that plugin. Running the script again while the floating window is open will close the window and switch back to track mode.

The requirements for this to work are to make a mapping for the plugin you want to control and then changing the `targetName` in the script to the desired plugin, as well as adding the script to REAPER action menu and assigning it to a hot key or one of the function buttons on the FaderPort.