### PR TITLE
Feature/316 respect slots

### DIFF
--- a/src/csurf_faderport_8/csurf_fp_8_general_control_manager.cpp
+++ b/src/csurf_faderport_8/csurf_fp_8_general_control_manager.cpp
@@ -236,9 +236,17 @@ public:
                                          ? trackNavigator->GetTrackByIndex(context->GetAddSendReceiveMode())
                                          : GetTrack(nullptr, context->GetCurrentSelectedSendReceive());
 
-            if (CreateTrackSend(src_track, dest_track) > -1) {
+            const int send_receive_index = CreateTrackSend(src_track, dest_track);
+            
+            if (send_receive_index > -1) {
                 context->SetAddSendReceiveMode(-1);
             }
+
+            if (settings->PluginsShouldRespectSlots() && !is_receive_mode) {
+                const int slot_index = context->GetChannelManagerItemIndex(99);
+                SetTrackSendInfo_Value(src_track, SEND_MODE_SEND, send_receive_index, "I_SLOT_HINT", slot_index);
+            }
+
             return;
         }
 

--- a/src/csurf_faderport_8/csurf_fp_8_hui_plugins_manager.cpp
+++ b/src/csurf_faderport_8/csurf_fp_8_hui_plugins_manager.cpp
@@ -37,8 +37,7 @@ public:
         CSurf_FP_8_PluginsManager::UpdateTracks(true);
     }
 
-    ~CSurf_FP_8_PluginsManager() override {
-    }
+    ~CSurf_FP_8_PluginsManager() override = default;
 
     void UpdateTracks(const bool force_update) override {
         nb_plugins = 0;
@@ -65,10 +64,10 @@ public:
 
         for (int i = 0; i < context->GetNbChannels(); i++) {
             MediaTrack *media_track;
+            const CSurf_FP_8_Track *track = tracks.at(i);
+
             int fader_value = 0;
             int value_bar_value = 0;
-
-            CSurf_FP_8_Track *track = tracks.at(i);
 
             if (context->GetMasterFaderMode() && i == context->GetNbChannels() - 1) {
                 media_track = GetMasterTrack(nullptr);

--- a/src/csurf_faderport_8/csurf_fp_8_hui_plugins_manager.cpp
+++ b/src/csurf_faderport_8/csurf_fp_8_hui_plugins_manager.cpp
@@ -5,10 +5,10 @@
 #include "../shared/csurf_plugin_utils.hpp"
 
 class CSurf_FP_8_PluginsManager : public CSurf_FP_8_ChannelManager {
-protected:
     int nb_plugins = 0;
     int current_plugin = 0;
 
+protected:
     void GetFaderValue(MediaTrack *media_track, int *fader_value, int *value_bar_value) const {
         int panMode = 0;
         double volume = 0.0;
@@ -43,6 +43,7 @@ public:
     void UpdateTracks(const bool force_update) override {
         nb_plugins = 0;
         const WDL_PtrList<MediaTrack> media_tracks = navigator->GetBankTracks();
+        const bool respect_slots = settings->PluginsShouldRespectSlots();
 
         for (int i = 0; i < context->GetNbChannels(); i++) {
             MediaTrack *media_track;
@@ -53,12 +54,10 @@ public:
                 media_track = media_tracks.Get(i);
             }
 
-            const int _nb_track_plugins = TrackFX_GetCount(media_track);
+            const int _nb_track_plugins = DAW::GetTrackFxCount(media_track, respect_slots);
             nb_track_items[i] = _nb_track_plugins;
 
-            if (_nb_track_plugins > nb_plugins) {
-                nb_plugins = _nb_track_plugins;
-            }
+            nb_plugins = std::max(_nb_track_plugins, nb_plugins);
         }
 
         context->SetChannelManagerItemsCount(nb_plugins);
@@ -66,21 +65,29 @@ public:
 
         for (int i = 0; i < context->GetNbChannels(); i++) {
             MediaTrack *media_track;
-            int fader_value = 0, value_bar_value = 0;
-            const int plugin_index = context->GetChannelManagerItemIndex(nb_track_items[i] - 1);
+            int fader_value = 0;
+            int value_bar_value = 0;
 
             CSurf_FP_8_Track *track = tracks.at(i);
+
             if (context->GetMasterFaderMode() && i == context->GetNbChannels() - 1) {
                 media_track = GetMasterTrack(nullptr);
             } else {
                 media_track = media_tracks.Get(i);
             }
 
-            if (!media_track) {
+            if (media_track == nullptr) {
                 track->ClearTrack(true, force_update);
                 continue;
             }
 
+            const int slot_index = context->GetChannelManagerItemIndex(
+                respect_slots ? nb_plugins : nb_track_items[i] - 1
+            );
+
+            const int plugin_index = respect_slots
+                                         ? DAW::GetTrackFxIndexBySlotIndex(media_track, slot_index)
+                                         : slot_index;
             SetTrackColors(media_track, DAW::IsTrackSelected(media_track), false);
             GetFaderValue(media_track, &fader_value, &value_bar_value);
 
@@ -92,7 +99,7 @@ public:
                     NON_INVERT,
                     force_update
                 );
-                track->SetDisplayLine(\
+                track->SetDisplayLine(
                     1,
                     ALIGN_LEFT,
                     DAW::GetTrackFxName(media_track, plugin_index, false).c_str(),
@@ -109,7 +116,7 @@ public:
                 track->SetDisplayLine(
                     3,
                     ALIGN_CENTER,
-                    Progress(plugin_index + 1, nb_track_items[i]).c_str(),
+                    Progress(slot_index + 1, respect_slots ? nb_plugins : nb_track_items[i]).c_str(),
                     NON_INVERT,
                     force_update
                 );
@@ -127,7 +134,16 @@ public:
                 track->SetDisplayLine(0, ALIGN_LEFT, DAW::GetTrackName(media_track).c_str(), NON_INVERT, force_update);
                 track->SetDisplayLine(1, ALIGN_LEFT, "No Fx", INVERT, force_update);
                 track->SetDisplayLine(2, ALIGN_CENTER, "", NON_INVERT, force_update);
-                track->SetDisplayLine(3, ALIGN_CENTER, "", NON_INVERT, force_update);
+                // When in slot mode, we always show th eprogress
+                track->SetDisplayLine(
+                    3,
+                    ALIGN_CENTER,
+                    respect_slots
+                        ? Progress(slot_index + 1, respect_slots ? nb_plugins : nb_track_items[i]).c_str()
+                        : "",
+                    NON_INVERT,
+                    force_update
+                );
                 track->SetMuteButtonValue(BTN_VALUE_OFF, force_update);
                 track->SetSoloButtonValue(BTN_VALUE_OFF, force_update);
             }
@@ -179,9 +195,13 @@ public:
         if (value == 0) {
             return;
         }
+        const bool respect_slots = settings->PluginsShouldRespectSlots();
 
         MediaTrack *media_track = navigator->GetTrackByIndex(index);
-        const int plugin_index = context->GetChannelManagerItemIndex(nb_track_items[index] - 1);
+        const int slot_index = context->GetChannelManagerItemIndex(nb_track_items[index] - 1);
+        const int plugin_index = respect_slots
+                                     ? DAW::GetTrackFxIndexBySlotIndex(media_track, slot_index)
+                                     : slot_index;
 
         // If the current plugin window is open, close it
         // Otherwise Close all other open windows and open the plugin window

--- a/src/csurf_faderport_8/csurf_fp_8_hui_sends_manager.cpp
+++ b/src/csurf_faderport_8/csurf_fp_8_hui_sends_manager.cpp
@@ -1,8 +1,6 @@
 #ifndef CSURF_FP_8_SENDS_MANAGER_C_
 #define CSURF_FP_8_SENDS_MANAGER_C_
 
-#include <algorithm>
-
 #include <WDL/db2val.h>
 #include "csurf_fp_8_channel_manager.hpp"
 
@@ -52,11 +50,12 @@ public:
     void UpdateTracks(const bool force_update) override {
         nb_sends = 0;
         const WDL_PtrList<MediaTrack> media_tracks = navigator->GetBankTracks();
+        const bool respect_slots = settings->SendsShouldRespectSlots();
         MediaTrack *add_send_track;
 
         for (int i = 0; i < context->GetNbChannels(); i++) {
             MediaTrack *media_track = media_tracks.Get(i);
-            const int _nb_track_sends = GetTrackNumSends(media_track, 0x10000000);
+            const int _nb_track_sends = DAW::GetTrackSendCount(media_track, respect_slots);
 
             nb_track_items[i] = _nb_track_sends;
             nb_sends = std::max(_nb_track_sends, nb_sends);
@@ -66,23 +65,30 @@ public:
         current_send = context->GetChannelManagerItemIndex();
 
         for (int i = 0; i < context->GetNbChannels(); i++) {
-            const int send_index = context->GetChannelManagerItemIndex(nb_track_items[i] - 1);
-            const bool add_send_enabled = context->GetAddSendReceiveMode() == i;
-
-            if (add_send_enabled) {
-                add_send_track = GetTrack(nullptr, context->GetCurrentSelectedSendReceive());
-            }
-
-            int pan, fader_value, value_bar_value = 0;
-            std::string pan_str;
-
-            CSurf_FP_8_Track *track = tracks.at(i);
+            const CSurf_FP_8_Track *track = tracks.at(i);
             MediaTrack *media_track = media_tracks.Get(i);
 
             if (!media_track) {
                 track->ClearTrack(true, force_update);
                 continue;
             }
+
+            const int slot_index = context->GetChannelManagerItemIndex(
+                respect_slots ? nb_sends : nb_track_items[i] - 1
+            );
+            const int send_index = respect_slots
+                                       ? DAW::GetTrackSendIndexBySlotIndex(media_track, slot_index)
+                                       : slot_index;
+            const bool add_send_enabled = context->GetAddSendReceiveMode() == i;
+
+            if (add_send_enabled) {
+                add_send_track = GetTrack(nullptr, context->GetCurrentSelectedSendReceive());
+            }
+
+            int pan = 0;
+            int fader_value = 0;
+            int value_bar_value = 0;
+            std::string pan_str;
 
             SetTrackColors(media_track, DAW::IsTrackSelected(media_track), false);
 
@@ -123,7 +129,7 @@ public:
                 track->SetDisplayLine(
                     3,
                     ALIGN_CENTER,
-                    Progress(send_index + 1, nb_track_items[i]).c_str(),
+                    Progress(slot_index + 1, respect_slots ? nb_sends : nb_track_items[i]).c_str(),
                     NON_INVERT,
                     force_update
                 );
@@ -146,11 +152,21 @@ public:
                         INVERT,
                         force_update
                     );
+                    track->SetDisplayLine(3, ALIGN_CENTER, "", NON_INVERT, force_update);
                 } else {
                     track->SetDisplayLine(1, ALIGN_LEFT, "No Sends", INVERT, force_update);
                     track->SetDisplayLine(2, ALIGN_CENTER, "", NON_INVERT, force_update);
+                    track->SetDisplayLine(
+                        3,
+                        ALIGN_CENTER,
+                        respect_slots
+                            ? Progress(slot_index + 1, respect_slots ? nb_sends : nb_track_items[i]).
+                            c_str()
+                            : "",
+                        NON_INVERT,
+                        force_update
+                    );
                 }
-                track->SetDisplayLine(3, ALIGN_CENTER, "", NON_INVERT, force_update);
                 track->SetFaderValue(0, force_update);
                 track->SetValueBarMode(VALUEBAR_MODE_FILL);
                 track->SetValueBarValue(0);

--- a/src/csurf_faderport_8/csurf_fp_8_hui_sends_manager.cpp
+++ b/src/csurf_faderport_8/csurf_fp_8_hui_sends_manager.cpp
@@ -201,7 +201,6 @@ public:
         /**
          * Set add_send_mode when right shift and select are engaged.
          * If add_send_mode is set, regardless the shift keys, we will reset the add_send_mode
-         *
          */
         if (context->GetShiftChannelLeft()) {
             if (context->GetAddSendReceiveMode() == -1) {

--- a/src/csurf_faderport_8/csurf_fp_8_hui_sends_manager.cpp
+++ b/src/csurf_faderport_8/csurf_fp_8_hui_sends_manager.cpp
@@ -68,7 +68,7 @@ public:
             const CSurf_FP_8_Track *track = tracks.at(i);
             MediaTrack *media_track = media_tracks.Get(i);
 
-            if (!media_track) {
+            if (media_track == nullptr) {
                 track->ClearTrack(true, force_update);
                 continue;
             }

--- a/src/i18n/locales/en-US.ini
+++ b/src/i18n/locales/en-US.ini
@@ -193,7 +193,7 @@ automation-single.point.shape.slow-start-end = Slow Start and End
 automation-single.point.shape.fast-start = Fast start
 automation-single.point.shape.fast-end = Fast end
 automation-single.point.shape.bezier = Bezier (Use slider below for the tension)
-single-point-button-blink.label = Blink Trim button when Single point automation
+single-point-button-blink.label = Blink Trim button when Single point automation is activated
 single-point-button-blink.tooltip = Trim button blinks when Single point automation is engaged. As this is a separate setting it is not turned off when distraction free mode is enabled
 
 

--- a/src/i18n/locales/en-US.ini
+++ b/src/i18n/locales/en-US.ini
@@ -154,6 +154,7 @@ master-fader.label = Enable master fader mode
 master-fader.tooltip = When selected en pressing the master button will enable master fader mode. This makes the last track of the FaderPort control the master track.
 mute-master-on-fwd-rwd.label = Mute the master track on Fwd and Rwd
 mute-master-on-fwd-rwd.tooltip = When fast worard or ewind the playhead, the master channel gets muted
+
 ; Filters
 custom-filter-group.label = Custom Filters
 instant-multi-select-filter.label = Instant apply filter in multi select
@@ -162,6 +163,11 @@ filter-use-custom-color.label = Use custom colors for the filters
 filter-use-custom-color.tooltip = When engaged, the color selected with the filter is used for the select button. Else the buttons are white.
 filter-use-project-filters.label = Use project filters
 filter-use-project-filters.tooltip = When engaged, project filters are enabled. This gives you the ability to create filters per project. This can also be used for adding filters to a project template.
+
+; Sends and Receives
+sends-receives-group.label = Sends & Receives
+sends-respect-slots.label = Respect slots for sends
+sends-respect-slots.tooltip = When enabled, the sends and hardware outputs will have the same order as in REAPER including the empty slots.
 
 ; Automation
 ; Colors
@@ -196,6 +202,8 @@ plugin-control-group.label = Plugin Control
 plugin-mapping-group.label = Plugin Mapping
 plugin-control.label = Disable Plugin Control
 plugin-control.tooltip = If you use another controller for controlling the plugins, you can select this. The plugins mode is still active and you are still able to open the plugin window. From that point, the ReaSonus FaderPort will not do anything anymore for the plugins.
+plugin-respect-slots.label = Respect slots for plufins
+plugin-respect-slots.tooltip = When enabled, the plugins will have the same order as in REAPER including the empty slots.
 untouch-after-learn.label = Untouch last touched param after learn
 untouch-after-learn.tooltip = When selected the last touched param will be set to untouched after parameter learn.
 plugin-step-size.label = Step size when scrolling through plugin parameters

--- a/src/shared/csurf_daw.cpp
+++ b/src/shared/csurf_daw.cpp
@@ -412,7 +412,7 @@ int DAW::GetTrackFxCount(MediaTrack *media_track, bool slots) {
     }
 
     char slot_index[256] = "";
-    TrackFX_GetNamedConfigParm(media_track, fx_count - 1, "slot_hint", slot_index, sizeof slot_index);
+    TrackFX_GetNamedConfigParm(media_track, fx_count - 1, "chain_index_to_slot", slot_index, sizeof slot_index);
 
     return std::stoi(slot_index) + 1;
 }
@@ -423,7 +423,7 @@ int DAW::GetTrackFxIndexBySlotIndex(MediaTrack *media_track, const int _slot_ind
     int fx_index = -1;
 
     for (auto i = 0; i < fx_count; i++) {
-        TrackFX_GetNamedConfigParm(media_track, i, "slot_hint", slot_index, sizeof slot_index);
+        TrackFX_GetNamedConfigParm(media_track, i, "chain_index_to_slot", slot_index, sizeof slot_index);
         const int index = std::stoi(slot_index);
 
         if (index == _slot_index) {

--- a/src/shared/csurf_daw.cpp
+++ b/src/shared/csurf_daw.cpp
@@ -404,6 +404,41 @@ void DAW::ToggleTrackFxBypass(MediaTrack *media_track) {
     }
 }
 
+int DAW::GetTrackFxCount(MediaTrack *media_track, bool slots) {
+    const int fx_count = TrackFX_GetCount(media_track);
+
+    if (!slots || fx_count < 1) {
+        return fx_count;
+    }
+
+    char slot_index[256] = "";
+    TrackFX_GetNamedConfigParm(media_track, fx_count - 1, "slot_hint", slot_index, sizeof slot_index);
+
+    return std::stoi(slot_index) + 1;
+}
+
+int DAW::GetTrackFxIndexBySlotIndex(MediaTrack *media_track, const int _slot_index) {
+    const int fx_count = TrackFX_GetCount(media_track);
+    char slot_index[256] = "";
+    int fx_index = -1;
+
+    for (auto i = 0; i < fx_count; i++) {
+        TrackFX_GetNamedConfigParm(media_track, i, "slot_hint", slot_index, sizeof slot_index);
+        const int index = std::stoi(slot_index);
+
+        if (index == _slot_index) {
+            fx_index = i;
+            break;
+        }
+        if (index == -1 && i == _slot_index) {
+            fx_index = i;
+            break;
+        }
+    }
+
+    return fx_index;
+}
+
 /************************************************************************
  * Track FX Param
  ************************************************************************/

--- a/src/shared/csurf_daw.cpp
+++ b/src/shared/csurf_daw.cpp
@@ -404,7 +404,7 @@ void DAW::ToggleTrackFxBypass(MediaTrack *media_track) {
     }
 }
 
-int DAW::GetTrackFxCount(MediaTrack *media_track, bool slots) {
+int DAW::GetTrackFxCount(MediaTrack *media_track, const bool slots) {
     const int fx_count = TrackFX_GetCount(media_track);
 
     if (!slots || fx_count < 1) {
@@ -617,7 +617,7 @@ bool DAW::HasTrackSend(MediaTrack *media_track, const int send) {
 }
 
 bool DAW::HasTrackHardwareOut(MediaTrack *media_track, const int send) {
-    return GetSetTrackSendInfo(media_track, SEND_MODE_HARDWARE, send, "I_SLOT_HINT", nullptr) != nullptr;
+    return GetSetTrackSendInfo(media_track, SEND_MODE_HARDWARE, send, "P_DESTTRACK", nullptr) == nullptr;
 }
 
 std::string DAW::GetTrackSendName(MediaTrack *media_track, const int send) {
@@ -628,6 +628,61 @@ std::string DAW::GetTrackSendName(MediaTrack *media_track, const int send) {
     }
 
     return "No Dest";
+}
+
+int DAW::GetTrackSendCount(MediaTrack *media_track, const bool slots) {
+    const int sends_count = GetTrackNumSends(media_track, SEND_MODE_SEND);
+    const int hardware_count = GetTrackNumSends(media_track, SEND_MODE_HARDWARE);
+
+    if (!slots || (sends_count + hardware_count) < 1) {
+        return sends_count + hardware_count;
+    }
+
+    return GetTrackNumSends(media_track, 0x10000000);
+}
+
+int DAW::GetTrackSendIndexBySlotIndex(MediaTrack *media_track, const int _slot_index) {
+    const int hardware_count = GetTrackNumSends(media_track, SEND_MODE_HARDWARE);
+    const int sends_count = GetTrackNumSends(media_track, SEND_MODE_SEND);
+    int send_index = -1;
+
+    for (auto i = 0; i < hardware_count; i++) {
+        const int hardware_slot_index = static_cast<int>(GetTrackSendInfo_Value(
+            media_track,
+            SEND_MODE_HARDWARE,
+            i,
+            "I_SLOT_HINT"
+        ));
+
+        if (hardware_slot_index == _slot_index) {
+            send_index = i;
+            break;
+        }
+        if (hardware_slot_index == -1 && i == _slot_index) {
+            send_index = i;
+            break;
+        }
+    }
+
+    for (auto i = 0; i < sends_count; i++) {
+        const int send_slot_index = static_cast<int>(GetTrackSendInfo_Value(
+            media_track,
+            SEND_MODE_SEND,
+            i,
+            "I_SLOT_HINT"
+        ));
+
+        if (send_slot_index == _slot_index) {
+            send_index = i + hardware_count;
+            break;
+        }
+        if (send_slot_index == -1 && (i + hardware_count) == _slot_index) {
+            send_index = i + hardware_count;
+            break;
+        }
+    }
+
+    return send_index;
 }
 
 int DAW::GetTrackSendMode(MediaTrack *media_track, const int send) {

--- a/src/shared/csurf_daw.hpp
+++ b/src/shared/csurf_daw.hpp
@@ -594,6 +594,23 @@ public:
     static std::string GetTrackSendName(MediaTrack *media_track, int send);
 
     /**
+     * Get the number of sends for the given track. When `slots` is set to true,
+     * it will count the number of slots used,
+     * @param media_track The track to get the number of plugins fpr
+     * @param slots Wether or not to keep slots in account
+     * @return Thenumber of pugins for the given track
+     */
+    static int GetTrackSendCount(MediaTrack *media_track, bool slots);
+
+    /**
+     * Get the track send index of the send with the corresponding slot index.
+     * @param media_track The track to get the send index for
+     * @param _slot_index The slot index to check
+     * @return
+     */
+    static int GetTrackSendIndexBySlotIndex(MediaTrack *media_track, int _slot_index);
+
+    /**
      * Get the send mode for the given send
      * @param media_track The track where we want the send for
      * @param send The index of the send track

--- a/src/shared/csurf_daw.hpp
+++ b/src/shared/csurf_daw.hpp
@@ -371,6 +371,23 @@ public:
     static void ToggleTrackFxBypass(MediaTrack *media_track);
 
     /**
+     * Get the number of plugons for the given track. When `slots` is set to true,
+     * it will count the number of slots used,
+     * @param media_track The track to get the number of plugins fpr
+     * @param slots Wether or not to keet slots in account
+     * @return Thenumber of pugins for the given track
+     */
+    static int GetTrackFxCount(MediaTrack *media_track, bool slots);
+
+    /**
+     * Get the track fx index of the fx with the corresponding slot index.
+     * @param media_track The track to get the fx inex for
+     * @param _slot_index The slot index to check
+     * @return
+     */
+    static int GetTrackFxIndexBySlotIndex(MediaTrack *media_track, int _slot_index);
+
+    /**
      * Get the parameter name of the parameter with the given values
      * @param media_track The track where we want the plugin param for
      * @param fx_index The index on the plugin

--- a/src/shared/csurf_daw.hpp
+++ b/src/shared/csurf_daw.hpp
@@ -11,7 +11,8 @@
 
 enum Features {
     FEATURE_PINNED_TRACKS,
-    FEATURE_EXTENSION_DATA
+    FEATURE_EXTENSION_DATA,
+    FEATURE_SLOTS
 };
 
 enum PAN_MODES {
@@ -44,6 +45,7 @@ enum SEND_SEND_MODES {
 static std::map<Features, double> feature_versions = { // NOLINT(*-statically-constructed-objects, *-throwing-static-initialization)
     {FEATURE_PINNED_TRACKS, 7.46},
     {FEATURE_EXTENSION_DATA, 7.79},
+    {FEATURE_SLOTS, 7.75},
 };
 
 class DAW {

--- a/src/shared/csurf_reasonus_settings.cpp
+++ b/src/shared/csurf_reasonus_settings.cpp
@@ -1,6 +1,8 @@
 #include "csurf_reasonus_settings.hpp"
 #include <array>
 #include <utility>
+
+#include "csurf_daw.hpp"
 #include "../shared/csurf_utils.hpp"
 
 ReaSonusSettings::ReaSonusSettings(std::string _device) {
@@ -233,6 +235,9 @@ bool ReaSonusSettings::ShouldClearParamInput() {
 }
 
 bool ReaSonusSettings::PluginsShouldRespectSlots() {
+    if (!DAW::VersionHasFeature(FEATURE_SLOTS)) {
+        return false;
+    }
     return stoi(settings["surface"]["plugin-respect-slots"]) > 0;
 }
 

--- a/src/shared/csurf_reasonus_settings.cpp
+++ b/src/shared/csurf_reasonus_settings.cpp
@@ -232,6 +232,10 @@ bool ReaSonusSettings::ShouldClearParamInput() {
     return stoi(settings["surface"]["plugin-map-param-clear"]) > 0;
 }
 
+bool ReaSonusSettings::PluginsShouldRespectSlots() {
+    return stoi(settings["surface"]["plugin-respect-slots"]) > 0;
+}
+
 int ReaSonusSettings::GetPluginMapDefaultColorMode() {
     return stoi(settings["surface"]["plugin-map-default-color-mode"]);
 }

--- a/src/shared/csurf_reasonus_settings.cpp
+++ b/src/shared/csurf_reasonus_settings.cpp
@@ -236,6 +236,10 @@ bool ReaSonusSettings::PluginsShouldRespectSlots() {
     return stoi(settings["surface"]["plugin-respect-slots"]) > 0;
 }
 
+bool ReaSonusSettings::SendsShouldRespectSlots() {
+    return stoi(settings["surface"]["sends-respect-slots"]) > 0;
+}
+
 int ReaSonusSettings::GetPluginMapDefaultColorMode() {
     return stoi(settings["surface"]["plugin-map-default-color-mode"]);
 }

--- a/src/shared/csurf_reasonus_settings.hpp
+++ b/src/shared/csurf_reasonus_settings.hpp
@@ -96,6 +96,7 @@ class ReaSonusSettings {
         {"surface", "time-code", "2"},
         {"surface", "track-color-brightness", "25"},
         {"surface", "plugin-step-size", "1"},
+        {"surface", "plugin-respect-slots", "0"},
         {"surface", "plugin-map-param-clear", "0"},
         {"surface", "plugin-map-default-color-mode", "1"},
         {
@@ -301,6 +302,8 @@ public:
     int GetMidiOutput();
 
     bool ShouldClearParamInput();
+
+    bool PluginsShouldRespectSlots();
 
     int GetPluginMapDefaultColorMode();
 

--- a/src/shared/csurf_reasonus_settings.hpp
+++ b/src/shared/csurf_reasonus_settings.hpp
@@ -94,6 +94,7 @@ class ReaSonusSettings {
         {"surface", "fader-reset", "0"},
         {"surface", "overwrite-time-code", "1"},
         {"surface", "time-code", "2"},
+        {"surface", "sends-respect-slots", "0"},
         {"surface", "track-color-brightness", "25"},
         {"surface", "plugin-step-size", "1"},
         {"surface", "plugin-respect-slots", "0"},
@@ -304,6 +305,8 @@ public:
     bool ShouldClearParamInput();
 
     bool PluginsShouldRespectSlots();
+
+    bool SendsShouldRespectSlots();
 
     int GetPluginMapDefaultColorMode();
 

--- a/src/ui/pages/csurf_ui_fp_8_settings_page.cpp
+++ b/src/ui/pages/csurf_ui_fp_8_settings_page.cpp
@@ -599,7 +599,8 @@ public:
                 ImGui::EndChild(m_ctx);
             }
 
-            if (!DAW::VersionHasFeature(FEATURE_SLOTS)) {
+            // Once we have more items under sends/receives, this has to be set around the `setting_sends_respect_slots` setting
+            if (DAW::VersionHasFeature(FEATURE_SLOTS)) {
                 if (ImGui::BeginChild(
                     m_ctx,
                     "sends-settings",
@@ -848,13 +849,13 @@ public:
                     i18n->t("settings", "plugin-control.tooltip")
                 );
 
-                if (!DAW::VersionHasFeature(FEATURE_SLOTS)) {
+                if (DAW::VersionHasFeature(FEATURE_SLOTS)) {
                     RenderInfoCheckbox(
                         m_ctx,
                         assets,
-                        i18n->t("settings", "plugin-respects-slots.label"),
+                        i18n->t("settings", "plugin-respect-slots.label"),
                         &setting_plugin_respect_slots,
-                        i18n->t("settings", "plugin-respects-slots.tooltip")
+                        i18n->t("settings", "plugin-respect-slots.tooltip")
                     );
                 }
 

--- a/src/ui/pages/csurf_ui_fp_8_settings_page.cpp
+++ b/src/ui/pages/csurf_ui_fp_8_settings_page.cpp
@@ -599,29 +599,30 @@ public:
                 ImGui::EndChild(m_ctx);
             }
 
-            if (ImGui::BeginChild(
-                m_ctx,
-                "sends-settings",
-                0.0,
-                0.0,
-                ImGui::ChildFlags_FrameStyle | ImGui::ChildFlags_AutoResizeY
-            )) {
-                ReaSonusPageTitle(
+            if (!DAW::VersionHasFeature(FEATURE_SLOTS)) {
+                if (ImGui::BeginChild(
                     m_ctx,
-                    assets,
-                    i18n->t("settings", "sends-receives-group.label"),
-                    true
-                );
+                    "sends-settings",
+                    0.0,
+                    0.0,
+                    ImGui::ChildFlags_FrameStyle | ImGui::ChildFlags_AutoResizeY
+                )) {
+                    ReaSonusPageTitle(
+                        m_ctx,
+                        assets,
+                        i18n->t("settings", "sends-receives-group.label"),
+                        true
+                    );
 
-                RenderInfoCheckbox(
-                    m_ctx,
-                    assets,
-                    i18n->t("settings", "sends-respect-slots.label"),
-                    &setting_sends_respect_slots,
-                    i18n->t("settings", "sends-respect-slots.tooltip")
-                );
-
-                ImGui::EndChild(m_ctx);
+                    RenderInfoCheckbox(
+                        m_ctx,
+                        assets,
+                        i18n->t("settings", "sends-respect-slots.label"),
+                        &setting_sends_respect_slots,
+                        i18n->t("settings", "sends-respect-slots.tooltip")
+                    );
+                    ImGui::EndChild(m_ctx);
+                }
             }
             UiStyledElements::PopReaSonusGroupStyle(m_ctx);
             ImGui::EndGroup(m_ctx);
@@ -844,21 +845,26 @@ public:
                     assets,
                     i18n->t("settings", "plugin-control.label"),
                     &setting_disable_plugins,
-                    i18n->t("settings", "plugin-control.tooltip"));
+                    i18n->t("settings", "plugin-control.tooltip")
+                );
 
-                RenderInfoCheckbox(
-                    m_ctx,
-                    assets,
-                    i18n->t("settings", "plugin-respects-slots.label"),
-                    &setting_plugin_respect_slots,
-                    i18n->t("settings", "plugin-respects-slots.tooltip"));
+                if (!DAW::VersionHasFeature(FEATURE_SLOTS)) {
+                    RenderInfoCheckbox(
+                        m_ctx,
+                        assets,
+                        i18n->t("settings", "plugin-respects-slots.label"),
+                        &setting_plugin_respect_slots,
+                        i18n->t("settings", "plugin-respects-slots.tooltip")
+                    );
+                }
 
                 RenderInfoCheckbox(
                     m_ctx,
                     assets,
                     i18n->t("settings", "untouch-after-learn.label"),
                     &setting_untouch_after_learn,
-                    i18n->t("settings", "untouch-after-learn.tooltip"));
+                    i18n->t("settings", "untouch-after-learn.tooltip")
+                );
 
                 RenderinfoIntInput(
                     m_ctx,
@@ -868,7 +874,8 @@ public:
                     1,
                     settings->GetSurface(),
                     i18n->t("settings", "plugin-step-size.tooltip"),
-                    "%d");
+                    "%d"
+                );
 
                 ImGui::EndChild(m_ctx);
             }

--- a/src/ui/pages/csurf_ui_fp_8_settings_page.cpp
+++ b/src/ui/pages/csurf_ui_fp_8_settings_page.cpp
@@ -1,18 +1,18 @@
 #include <array>
 #include "../csurf_ui_page_content.hpp"
-#include "../components/csurf_ui_checkbox.hpp"
-#include "../components/csurf_ui_int_input.hpp"
-#include "../components/csurf_ui_combo_input.hpp"
-#include "../../shared/csurf.h"
 #include "../../i18n/i18n.hpp"
-#include "../utils/csurf_ui_button_width.hpp"
+#include "../../shared/csurf.h"
 #include "../../shared/csurf_daw.hpp"
-#include "../windows/csurf_ui_fp_8_control_panel.hpp"
 #include "../../shared/csurf_reasonus_settings.hpp"
-#include "../components/csurf_ui_image_combo_input.hpp"
-#include "../components/csurf_ui_color_picker.hpp"
-#include "../components/csurf_ui_page_title.hpp"
 #include "../components/csurf_ui_automation_point_shape.hpp"
+#include "../components/csurf_ui_checkbox.hpp"
+#include "../components/csurf_ui_color_picker.hpp"
+#include "../components/csurf_ui_combo_input.hpp"
+#include "../components/csurf_ui_image_combo_input.hpp"
+#include "../components/csurf_ui_int_input.hpp"
+#include "../components/csurf_ui_page_title.hpp"
+#include "../utils/csurf_ui_button_width.hpp"
+#include "../windows/csurf_ui_fp_8_control_panel.hpp"
 
 class CSurf_FP_8_SettingsPage : public CSurf_UI_PageContent { // NOLINT(*-use-internal-linkage)
     I18n *i18n = I18n::GetInstance();
@@ -38,6 +38,7 @@ class CSurf_FP_8_SettingsPage : public CSurf_UI_PageContent { // NOLINT(*-use-in
     bool setting_filter_project_filters;
     bool setting_master_fader_mode;
     bool setting_mute_master_on_fwd_rwd;
+    bool setting_sends_respect_slots;
 
     // Automation
     bool setting_use_automation_colors;
@@ -597,6 +598,31 @@ public:
 
                 ImGui::EndChild(m_ctx);
             }
+
+            if (ImGui::BeginChild(
+                m_ctx,
+                "sends-settings",
+                0.0,
+                0.0,
+                ImGui::ChildFlags_FrameStyle | ImGui::ChildFlags_AutoResizeY
+            )) {
+                ReaSonusPageTitle(
+                    m_ctx,
+                    assets,
+                    i18n->t("settings", "sends-receives-group.label"),
+                    true
+                );
+
+                RenderInfoCheckbox(
+                    m_ctx,
+                    assets,
+                    i18n->t("settings", "sends-respect-slots.label"),
+                    &setting_sends_respect_slots,
+                    i18n->t("settings", "sends-respect-slots.tooltip")
+                );
+
+                ImGui::EndChild(m_ctx);
+            }
             UiStyledElements::PopReaSonusGroupStyle(m_ctx);
             ImGui::EndGroup(m_ctx);
 
@@ -1088,6 +1114,7 @@ public:
         settings->SetSetting("surface", "mute-solo-momentary", setting_momentary_mute_solo);
         settings->SetSetting("surface", "overwrite-time-code", setting_overwrite_time_code);
         settings->SetSetting("surface", "track-color-brightness", setting_track_color_brightness);
+        settings->SetSetting("surface", "sends-respect-slots", setting_sends_respect_slots);
         settings->SetSetting("surface", "latch-preview-action", setting_latch_preview_action_enable);
         settings->SetSetting("surface", "latch-preview-action-code",
                              latch_preview_action_indexes[setting_latch_preview_action]);
@@ -1147,6 +1174,7 @@ public:
         setting_overwrite_time_code = settings->GetOverwriteTimeCode();
         setting_latch_preview_action_enable = settings->GetLatchPreviewActionEnabled();
         setting_use_automation_colors = settings->UseAutomationColors();
+        setting_sends_respect_slots = settings->SendsShouldRespectSlots();
         setting_automation_colors = settings->GetAutomationColorsArray();
         setting_plugin_step_size = settings->GetpluginStepSize();
         setting_track_color_brightness = settings->GetTrackColorBrightness();

--- a/src/ui/pages/csurf_ui_fp_8_settings_page.cpp
+++ b/src/ui/pages/csurf_ui_fp_8_settings_page.cpp
@@ -62,6 +62,7 @@ class CSurf_FP_8_SettingsPage : public CSurf_UI_PageContent { // NOLINT(*-use-in
 
     // Plugins
     bool setting_disable_plugins;
+    bool setting_plugin_respect_slots;
     bool setting_untouch_after_learn;
     int setting_plugin_step_size;
     bool setting_plugin_map_param_clear;
@@ -822,6 +823,13 @@ public:
                 RenderInfoCheckbox(
                     m_ctx,
                     assets,
+                    i18n->t("settings", "plugin-respects-slots.label"),
+                    &setting_plugin_respect_slots,
+                    i18n->t("settings", "plugin-respects-slots.tooltip"));
+
+                RenderInfoCheckbox(
+                    m_ctx,
+                    assets,
                     i18n->t("settings", "untouch-after-learn.label"),
                     &setting_untouch_after_learn,
                     i18n->t("settings", "untouch-after-learn.tooltip"));
@@ -1086,6 +1094,7 @@ public:
         settings->SetSetting("surface", "automation-colors", join(setting_automation_colors, ","));
         settings->SetSetting("surface", "time-code", time_code_indexes[setting_time_code]);
         settings->SetSetting("surface", "plugin-step-size", setting_plugin_step_size);
+        settings->SetSetting("surface", "plugin-respect-slots", setting_plugin_respect_slots);
         settings->SetSetting("surface", "plugin-map-param-clear", setting_plugin_map_param_clear);
         settings->SetSetting("surface", "plugin-map-default-color-mode", setting_plugin_map_color_mode);
         settings->SetSetting("surface", "instant-multi-select-filter", setting_instant_multi_select_filter);
@@ -1141,6 +1150,7 @@ public:
         setting_automation_colors = settings->GetAutomationColorsArray();
         setting_plugin_step_size = settings->GetpluginStepSize();
         setting_track_color_brightness = settings->GetTrackColorBrightness();
+        setting_plugin_respect_slots = settings->PluginsShouldRespectSlots();
         setting_plugin_map_param_clear = settings->ShouldClearParamInput();
         setting_plugin_map_color_mode = settings->GetPluginMapDefaultColorMode();
         setting_track_display = settings->GetTrackDisplay();


### PR DESCRIPTION
Since REAPER 7.75 slots are available for sends and plugins.

In the branch slots are implemented as follows:
- Pan/Param encoder will scroll through the slots
- Progress indicates number Slots and current selected slot

### Sends

- In the ReaSonus Control Panel under Settings/Controller you can enable respecting send slots by enabling: **Respect slots for sends**
- When selecting Send the order where the sends are sorted are in the same order as slots including the empty slots
- When adding a send on-device now, this will be added to the current selected slot index
- Also hardware slots are respected in the sends list
- When feature is active, clicking [Left Shift] + [Mute Clear] will toggle the mute state for all sends and hardware outputs in the current selected slot

### Plugins

- In the ReaSonus Control Panel under Settings/Plugin Control you can enable respecting send slots by enabling: **Respect slots for plugins**
- When selecting Plugin the order where the sends are sorted are in the same order as slots including the empty slots
- When feature is active, clicking [Left Shift] + [Bypass] will toggle the bypass state for all plugins in the current selected slot


